### PR TITLE
Make undefined one character shorter

### DIFF
--- a/hieroglyphy.js
+++ b/hieroglyphy.js
@@ -47,7 +47,7 @@
     _NaN = "+{}+[]";
     _true = "!![]+[]";
     _false = "![]+[]";
-    _undefined = "[][+[]]+[]";
+    _undefined = "[][[]]+[]";
 
     characters[" "] = "(" + _object_Object + ")[" + numbers[7]  + "]";
     characters["["] = "(" + _object_Object + ")[" + numbers[0]  + "]";


### PR DESCRIPTION
You can get 'undefined' via `[][[]]`,  which is shorter than your current `[][+[]]`. Everything else looks awesome, though!
