### PR TITLE
Remove the requirement for extra http location string.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
+  - 6
+  - 8
+  - 10

--- a/hieroglyphy.js
+++ b/hieroglyphy.js
@@ -10,11 +10,11 @@
         _undefined,
         _Infinity,
         _1e100,
+        _String,
         characters,
         functionConstructor,
         escape,
         unescape,
-        locationString,
         API;
 
     numbers = [
@@ -71,6 +71,12 @@
     characters["N"] = "(" + _NaN + ")[" + numbers[0] + "]";
     characters["O"] = "(" + _object_Object + ")[" + numbers[8] + "]";
 
+    _String = "[]+" + "(" + _object_Object + ")" + "[" + hieroglyphyString("constructor") + "]"; // "‌function String() { [native code] }"
+
+    characters["S"] = "(" + _String + ")" + "[" + numbers[9] + "]";
+    characters["g"] = "(" + _String + ")" + "[" + "(" + numbers[7] + ")" + "+" + "(" + numbers[7] + ")" + "]";
+
+
     _Infinity = "+(" + numbers[1] + "+" + characters["e"] + "+" +
         characters[1] + "+" + characters[0] + "+" + characters[0] + "+" +
         characters[0] + ")+[]";
@@ -86,11 +92,11 @@
     functionConstructor = "[][" + hieroglyphyString("sort") + "][" +
         hieroglyphyString("constructor") + "]";
 
-    //Below characters need target http(s) pages
-    locationString = "[]+" + hieroglyphyScript("return location");
-    characters["h"] = "(" + locationString + ")" + "[" + numbers[0] + "]";
-    characters["p"] = "(" + locationString + ")" + "[" + numbers[3] + "]";
-    characters["/"] = "(" + locationString + ")" + "[" + numbers[6] + "]";
+    //Below characters need _String
+    characters["h"] = "(" + "(" + numbers[9] + ")" + "+" + "(" + numbers[8] + ")" + ")" +
+        "[" + hieroglyphyString("toString") + "]" + "(" + "(" + numbers[9] + ")" + "+" + "(" + numbers[9] + ")" + ")";
+    characters["p"] = "(" + "(" + numbers[9] + ")" + "+" + "(" + numbers[9] + ")" + "+" + "(" + numbers[7] + ")" + ")" +
+        "[" + hieroglyphyString("toString") + "]" + "(" + "(" + numbers[9] + ")" + "+" + "(" + numbers[9] + ")" + "+" + "(" + numbers[8] + ")" + ")";
 
     unescape = hieroglyphyScript("return unescape");
     escape = hieroglyphyScript("return escape");

--- a/test/node_test.js
+++ b/test/node_test.js
@@ -1,7 +1,6 @@
 var hieroglyphy = require("../hieroglyphy"),
     assert = require('assert');
 
-global.location = "http://example.com";
 global.testString = "foo";
 
 exports.testHieroglyphyCharacters = function () {


### PR DESCRIPTION
Hieroglyphy works very good on browser side.
But it require location property.
So I have to define the location property as a string start with "http://";
for the most important letter "p".
It seems like a kind of cheating.
So I tried to make some change.

I want to use "Number.toString()" to get the most important "p".

```javascript
(25).toString(26); //=>"p"

// In fact, this way may help to get the whole alphabet.
(35).toString(36); //=>"z". 0-9 is "0" - "9". 10-35 is "a" - "z".
```

To call the method "toString", I need "S" and "g".
Thanks for smart previous code, it is possible to call the constructor of anything. This helps me getting the letter "S" and "g".

```javascript
_String = "[]+" + "(" + _object_Object + ")" + "[" + hieroglyphyString("constructor") + "]"; // "‌function String() { [native code] }"
characters["S"] = "(" + _String + ")" + "[" + numbers[9] + "]";
characters["g"] = "(" + _String + ")" + "[" + "(" + numbers[7] + ")" + "+" + "(" + numbers[7] + ")" + "]";
```

It seems make the generated code longer(or not).
But anyway, Hieroglyphy only require ECMAScript features now.
We can keep finding better way.

